### PR TITLE
Announcements: Improved pagination metadata

### DIFF
--- a/routes/bulletinBoard/announcements/index.js
+++ b/routes/bulletinBoard/announcements/index.js
@@ -29,7 +29,27 @@ function getAnnouncements (req, res, next) {
     if (err || !announcements) {
       next(new ApplicationError('getAnnouncements', null, 1000, err, 'Συνεβη καποιο λάθος κατα την λήψη ανακοινώσεων.', getClientIp(req), 500, false))
     } else {
-      res.status(200).json(announcements)
+      database.Announcements.count(req.query.filters).select(req.query.fields).sort(req.query.sort).skip(parseInt(req.query.page) * parseInt(req.query.limit)).limit(parseInt(req.query.limit)).exec(function (err, totalResultCount) {
+        if (err) {
+          next(new ApplicationError('getAnnouncements', null, 1001, err, 'Συνεβη καποιο λάθος κατα την λήψη ανακοινώσεων', getClientIp(req), 500, false))
+        } else {
+          let resultCount = totalResultCount
+          if (parseInt(req.query.limit)) {
+            resultCount = parseInt(req.query.limit)
+          }
+          let totalPages = 1
+          if (parseInt(req.query.limit)) {
+            totalPages = Math.ceil(totalResultCount / parseInt(req.query.limit))
+          }
+          res.status(200).json({
+            'results': announcements,
+            'resultCount': resultCount,
+            'page': parseInt(req.query.page),
+            'totalResultCount': totalResultCount,
+            'totalPages': totalPages
+          })
+        }
+      })
     }
   })
 }
@@ -40,7 +60,7 @@ function getAnnouncement (req, res, next) {
     if (err) {
       next(new ApplicationError('getAnnouncement', null, 1021, err, 'Συνεβη καποιο λάθος κατα την λήψη ανακοινώσεων.', getClientIp(req), 500, false))
     } else {
-      if (announcement){
+      if (announcement) {
         announcementsFunc.checkIfEntryExists(announcement._about, database.AnnouncementsCategories).then(() => {
           if (req.user || announcement._about.public) {
             announcement._about.public = undefined // remove the public property
@@ -52,11 +72,9 @@ function getAnnouncement (req, res, next) {
             next(new ApplicationError('getAnnouncement', null, 1022, err, 'Δεν έχεις δικάιωμα για αυτήν την ενέργεια!', getClientIp(req), 401, false))
           }
         }).catch(next)
-      }
-      else {
+      } else {
         next(new ApplicationError('getAnnouncement', null, 1023, {}, 'Η ανακοίνωση δεν βρέθηκε.', getClientIp(req), 404, false))
       }
-  
     }
   })
 }

--- a/routes/bulletinBoard/announcements/index.js
+++ b/routes/bulletinBoard/announcements/index.js
@@ -29,7 +29,7 @@ function getAnnouncements (req, res, next) {
     if (err || !announcements) {
       next(new ApplicationError('getAnnouncements', null, 1000, err, 'Συνεβη καποιο λάθος κατα την λήψη ανακοινώσεων.', getClientIp(req), 500, false))
     } else {
-      database.Announcements.count(req.query.filters).select(req.query.fields).sort(req.query.sort).skip(parseInt(req.query.page) * parseInt(req.query.limit)).limit(parseInt(req.query.limit)).exec(function (err, totalResultCount) {
+      database.Announcements.count(req.query.filters).select(req.query.fields).sort(req.query.sort).exec(function (err, totalResultCount) {
         if (err) {
           next(new ApplicationError('getAnnouncements', null, 1001, err, 'Συνεβη καποιο λάθος κατα την λήψη ανακοινώσεων', getClientIp(req), 500, false))
         } else {

--- a/routes/bulletinBoard/announcements/index.js
+++ b/routes/bulletinBoard/announcements/index.js
@@ -33,11 +33,7 @@ function getAnnouncements (req, res, next) {
         if (err) {
           next(new ApplicationError('getAnnouncements', null, 1001, err, 'Συνεβη καποιο λάθος κατα την λήψη ανακοινώσεων', getClientIp(req), 500, false))
         } else {
-          const limit = parseInt(req.query.limit)
-          let resultCount = totalResultCount
-          if (limit && limit <= totalResultCount) {
-            resultCount = parseInt(req.query.limit)
-          }
+          let resultCount = announcements.length
           let totalPages = 1
           if (parseInt(req.query.limit)) {
             totalPages = Math.ceil(totalResultCount / parseInt(req.query.limit))
@@ -131,11 +127,7 @@ function getAnnouncementsPublic (req, res, next) {
                 if (err) {
                   next(new ApplicationError('getAnnouncementsPublic', null, 1013, err, 'Συνεβη καποιο λάθος κατα την λήψη ανακοινώσεων', getClientIp(req), 500, false))
                 } else {
-                  const limit = parseInt(req.query.limit)
-                  let resultCount = totalResultCount
-                  if (limit && limit <= totalResultCount) {
-                    resultCount = parseInt(req.query.limit)
-                  }
+                  let resultCount = announcements.length
                   let totalPages = 1
                   if (parseInt(req.query.limit)) {
                     totalPages = Math.ceil(totalResultCount / parseInt(req.query.limit))

--- a/routes/bulletinBoard/announcements/index.js
+++ b/routes/bulletinBoard/announcements/index.js
@@ -33,8 +33,9 @@ function getAnnouncements (req, res, next) {
         if (err) {
           next(new ApplicationError('getAnnouncements', null, 1001, err, 'Συνεβη καποιο λάθος κατα την λήψη ανακοινώσεων', getClientIp(req), 500, false))
         } else {
+          const limit = parseInt(req.query.limit)
           let resultCount = totalResultCount
-          if (parseInt(req.query.limit)) {
+          if (limit && limit <= totalResultCount) {
             resultCount = parseInt(req.query.limit)
           }
           let totalPages = 1
@@ -130,8 +131,9 @@ function getAnnouncementsPublic (req, res, next) {
                 if (err) {
                   next(new ApplicationError('getAnnouncementsPublic', null, 1013, err, 'Συνεβη καποιο λάθος κατα την λήψη ανακοινώσεων', getClientIp(req), 500, false))
                 } else {
+                  const limit = parseInt(req.query.limit)
                   let resultCount = totalResultCount
-                  if (parseInt(req.query.limit)) {
+                  if (limit && limit <= totalResultCount) {
                     resultCount = parseInt(req.query.limit)
                   }
                   let totalPages = 1


### PR DESCRIPTION
This PR modifies the responses of the following endpoints:
- `GET /announcements/` 
- `GET /announcements/public`

Previously, the API would respond to these requests like this:

```
[
  {
    "date": "2020-07-07T20:55:17.940Z",
    "attachments": [],
    ...
  }
]
```

With this PR, these responses have a new structure:
| Attribute          | Description                                                        |
|--------------------|--------------------------------------------------------------------|
| `results`          | Array containing the paginated results                             |
| `resultCount`      | The amount of results returned                                     |
| `page`             | The zero indexed number of the returned page                       |
| `totalResultCount` | The total amount of results that match this query                  |
| `totalPages`       | The total amount of pages available given the `pageSize` specified |

Example: `GET /announcements/public?pageSize=1&page=3`
```
{
  "results": [
    {
      "date": "2020-07-07T20:55:17.398Z",
      "attachments": [],
       ...
    }
  ],
  "resultCount": 1,
  "page": 3,
  "totalResultCount": 12,
  "totalPages": 12
}
```

Because these changes were made possible using an additional query to get the resulting metadata, the following error codes have been added to handle exceptions during its execution:

| Error Code | Meaning                                      |
|------------|----------------------------------------------|
| 1001       | Failure to get count of Announcements        |
| 1012       | Failure to get count of Public Announcements |

I am aware these could be breaking changes for these essential routes, but consuming the API using pagination becomes much easier when more pagination metadata are available. Result filtering, selecting, and sorting are fully functional with this PR.